### PR TITLE
Hooks are not reentrant

### DIFF
--- a/press/entry.py
+++ b/press/entry.py
@@ -8,6 +8,7 @@ from press.configuration.util import set_environment_from_file, environment_cach
 from press.log import setup_logging
 from press.plugin_init import init_plugins
 from press.press import Press
+from press.hooks.hooks import clear_hooks
 
 log = logging.getLogger('press')
 
@@ -42,3 +43,4 @@ def entry_main(
     finally:
         if press.layout.committed:
             press.teardown()
+        clear_hooks()

--- a/press/hooks/hooks.py
+++ b/press/hooks/hooks.py
@@ -21,8 +21,14 @@ valid_hook_points = ["post-press-init", "pre-apply-layout", "pre-mount-fs",
                      "pre-target-run", "pre-extensions", "post-extensions"]
 target_hooks = {}
 
+
 for valid_point in valid_hook_points:
     target_hooks[valid_point] = []
+
+
+def clear_hooks():
+    for point in target_hooks:
+        del target_hooks[point][:]
 
 
 def add_hook(func, point, hook_name=None, *args, **kwargs):


### PR DESCRIPTION
This is a hack, hooks should be redesigned. Adding a loader (rather than
runtime load) would be preferable. Right now, clear hooks has to be
called before a process can make a threaded call to press.